### PR TITLE
Improve ospology meetings documentation

### DIFF
--- a/meetings/README.md
+++ b/meetings/README.md
@@ -1,7 +1,7 @@
 # OSPOlogy Monthly Meetings
 
 1. [What are OSPOlogy Monthly Meetings?](#what-are-ospology-monthly-meetings)
-2. [Event Page and past meetings](#event-page-and-past-meetings)
+2. [Event Page and past sessions](#event-page-and-past-sessions)
 3. [OSPOlogy Planning](#ospology-planning)
 
 

--- a/meetings/README.md
+++ b/meetings/README.md
@@ -1,8 +1,39 @@
 # OSPOlogy Monthly Meetings
 
-## Event Page
+1. [What are OSPOlogy Monthly Meetings?](#what-are-ospology-monthly-meetings)
+2. [Event Page and past meetings](#event-page-and-past-meetings)
+3. [OSPOlogy Planning](#ospology-planning)
 
-OSPOlogy are public monthly meetings of the TODO Group and wider OSPO community, everyone is welcome to attend:
+
+## What are OSPOlogy Monthly Meetings?
+
+OSPOlogy community meetings are public monthly meetings of the TODO Group and wider OSPO community, everyone is welcome to attend and participate.
+The community is welcome to participate in the several activities of the planning process:
+
+**🙋 Bring topics of interest to the wider OSPO community**
+
+Some examples include:
+
+* Present WIP or finished projects being done at your OSPO or open source initiative
+* Share OSPO journey history behind your OSPO
+* Share OSPO tooling that help the main activities of an OSPO
+* Present research studies and/ or whitepapers to the community 
+* Present a proposal for a potential research or whitepaper 
+
+>Getting started: If you have a story to share, please add your topic to the following [CFP form](https://github.com/todogroup/ospology/issues/new/choose)
+
+**🗳 Vote for upcoming sessions**
+
+Topics are proposed by the community (via CFP submission) and selected by OSPOlogy Maintainers. You can learn more in the [GOVERNANCE.md file](https://github.com/todogroup/ospology/blob/main/meetings/GOVERNANCE.md)
+
+To see existing proposals, take a look to ['ospology cfp' label](https://github.com/todogroup/ospology/issues?q=is%3Aissue+is%3Aopen+label%3A%22ospology+cfp%22).
+
+**💬 Moderate a OSPOlogy session**
+
+
+## Event Page and Past Sessions
+
+OSPOlogy meetings are published via LFQH Community Platform where everyone is welcome to attend:
 https://community.linuxfoundation.org/todo-group/
 
 * [August 4 2021 - OSPOlogy: How to start an OSPO](https://community.linuxfoundation.org/events/details/lfhq-todo-group-presents-ospology-how-to-start-an-ospo-program/) - [Meeting Slides](https://docs.google.com/presentation/d/1avhKMhFi9PJS9ktGJ6HdF5SOk972KBZr51x30kVxzsc/edit?usp=sharing)
@@ -11,15 +42,15 @@ https://community.linuxfoundation.org/todo-group/
 *  [November 17 2021 - OSPOlogy: Academic OSPOs](https://community.linuxfoundation.org/events/details/lfhq-todo-group-presents-academic-ospos-fostering-open-source-culture-at-universities/) - [Meeting Slides](https://docs.google.com/presentation/d/1cf8ltMP8d6Ie6jZ0mz-rVw_lj1Ys3kZzS_L8U3iChG8/edit?usp=sharing)
 *  [December 1 2021 - OSPology: Governance in the Context of Compliance and Security](https://community.linuxfoundation.org/events/details/lfhq-todo-group-presents-ospology-governance-in-the-context-of-compliance-and-security/) - [Meeting Slides](https://docs.google.com/presentation/d/1oMumdl4yMSeZ2wkHU9-MQaf9jYV0dHeYhzilA5oPsmY/edit?usp=sharing)
 
-## Planning
+
+## OSPOlogy Planning
 
 The planning document for meetings is here: https://docs.google.com/document/d/1_J2N2mi3vP1vdOtlvcBNEUh1M1Hawl8mu403HU3wEqQ/edit#heading=h.oqjgzg5a7to2
-
-**Scheduled topics**
-
-Scheduled topics can be found on the [Schedule sessions sheet](https://docs.google.com/spreadsheets/d/1Ke-GONN9IL8x1jww93HMXmDmC69JzlSGoUJIQdfrOgg/edit?usp=sharing)
-
 
 **OSPOlogy CFP**
 
 If you have a story to share, please add your topic to the following [CFP form](https://github.com/todogroup/ospology/issues/new/choose)
+
+**Governance Guidelines**
+
+Learn how to become an OSPOlogy maintainer at [governance.md](https://github.com/todogroup/ospology/blob/main/meetings/GOVERNANCE.md)


### PR DESCRIPTION
This commit clarifies the expected topics to be discussed during an OSPOlogy session and improves overall documentation on how to submit a proposal