### PR TITLE
create governance.md for ospo mind map project

### DIFF
--- a/ospo-mindmap/GOVERNANCE.md
+++ b/ospo-mindmap/GOVERNANCE.md
@@ -1,0 +1,30 @@
+# Mind Map Governance
+
+This document defines the governance process for the OSPO Mind Map.
+
+## Changes in Maintainership
+
+On successful merge of a significant pull request any current maintainer can reach to the author behind the pull request and ask them if they are willing to become a mainatiner. They can send a PR to [settings.yml file](https://github.com/todogroup/ospology/blob/main/.github/settings.yml#L18) and request the existing maintainers to vote them in.
+
+If a maintainer feels she/he/they can not fulfill the "Expectations from Maintainers", they are free to step down.
+
+## Feature request voting process
+
+Feature requests are proposed by the community and selected by **OSPOlogy Maintainers**. Current mainainers are listed in [settings.yml file](https://github.com/todogroup/ospology/blob/main/.github/settings.yml#L18).
+
+To become a new maintainer, contirbutors shall be responsible to:
+
+* Actively participate in PR reviews and respond in a timely fahsion
+* Contribute to OSPO Mind Map by improving project documentation, mind map content, visibility or accessibility.
+
+In case of conflict resolution, the [TODO Steering Committee](https://github.com/todogroup/governance/blob/master/CHARTER.adoc) will have the final oversight of the feature requests.
+
+All voting is done via a simple majority of maintainers.
+
+## Expectations from Maintainers
+
+Every one carries water and helps out!
+
+Every maintainer is listed in the [settings.yml file](https://github.com/todogroup/ospology/blob/main/.github/settings.yml#L18) 
+
+Making a community work requires input and effort from everyone. Maintainers should actively participate in PR reviews and respond in a timely fahsion.


### PR DESCRIPTION
This new file sets the governance process, including:

- How contributors can become maintainers
- Feature request voting process
- Maintainer expectations