### PR TITLE
update governance.md for ospology meetings

### DIFF
--- a/meetings/GOVERNANCE.md
+++ b/meetings/GOVERNANCE.md
@@ -14,8 +14,10 @@ Topics are proposed by the community and selected by **OSPOlogy Maintainers**. C
 
 To become a new maintainer, contirbutors shall be responsible to:
 
-* Attend to the monthly Sync meetings to decide upcoming topics proposed by the community
-* Contribute to OSPOlogy monthly meeting [planning documentation](https://docs.google.com/document/d/1_J2N2mi3vP1vdOtlvcBNEUh1M1Hawl8mu403HU3wEqQ/edit?usp=sharing)
+* Actively participate in the [CFP issues](https://github.com/todogroup/ospology/issues?q=is%3Aissue+is%3Aopen+label%3A%22ospology+cfp%22) proposed by the community to decide upcoming topics.
+* Contribute to OSPOlogy monthly meeting [planning documentation](https://docs.google.com/document/d/1_J2N2mi3vP1vdOtlvcBNEUh1M1Hawl8mu403HU3wEqQ/edit?usp=sharing).
+* Actively promote upcomming OSPOlogy meetings or create related content on social media and/or external mailing lists (e.g create OSPOlogy infographics, recap videos, share TODO OSPOlogy Announcements, etc).
+* Be able to moderate an OSPOlogy meeting, if neccessary
 
 In case of conflict resolution, the [TODO Steering Committee](https://github.com/todogroup/governance/blob/master/CHARTER.adoc) will have the final oversight of the selected topics.
 


### PR DESCRIPTION
OSPOlogy meeting topic proposals are now done via a CFP issue form. This info should be updated in the governance.md. This PR updates governance.md for ospology meetings