### PR TITLE
Remove "=" typo

### DIFF
--- a/newsletter/2022-05-31.md
+++ b/newsletter/2022-05-31.md
@@ -37,7 +37,7 @@ A list of OSPO related jobs published during this month!
 * [Google: Open-Source Strategy Program Manager](https://careers.google.com/jobs/results/102679127212860102/)
 * [Carnegie Mellon University: Director, Open Source Program Office](https://www.linkedin.com/jobs/view/director-open-source-program-office-at-carnegie-mellon-university-3060931703/)
 * [Citi: Developer Engineering - Open Source Operations Lead](https://jobs.citi.com/job/london/developer-engineering-open-source-operations-lead/287/18896957344)
-* [GitHub: Senior Product Manager, OSPO](https://boards.greenhouse.io/github/jobs/3910679)=
+* [GitHub: Senior Product Manager, OSPO](https://boards.greenhouse.io/github/jobs/3910679)
 * [New Relic: Senior Software Engineer (Open Source Program) - Remote](https://newrelic.com/about/careers?p=job%2FoDrwgfwA)
 * [Amazon: Open Source Engineer - US, Virtual](https://www.amazon.jobs/en/jobs/2015831/open-source-engineer-open-source?no_int_redir=1)
 


### PR DESCRIPTION
I was scrolling through the newsletter and noticed a typo on the GitHub role so I removed the "=".