### PR TITLE
Add standards collaboration

### DIFF
--- a/ospo-mindmap/Content/ospomindmap.md
+++ b/ospo-mindmap/Content/ospomindmap.md
@@ -33,7 +33,7 @@ efficient through sharing costs and innovation for industry-specific needs
 ### Standards Collaborative
 
 - `Definition` Support relevant standards in open source projects and provide feedback to corresponding standards organizations
-- `Example:` OpenDaylight community collaborates with IETF standards community on NETCONF, RESTCONF, YANG, and YANG models
+- `Example:` Let's Encrypt community collaborates with IETF standards community on ACME, TLS, and other work related to X.509 certificates
 
 ### Big Project Facilitators
 

--- a/ospo-mindmap/Content/ospomindmap.md
+++ b/ospo-mindmap/Content/ospomindmap.md
@@ -34,6 +34,7 @@ efficient through sharing costs and innovation for industry-specific needs
 
 - `Definition` Support relevant standards in open source projects and provide feedback to corresponding standards organizations
 - `Example:` Let's Encrypt community collaborates with IETF standards community on ACME, TLS, and other work related to X.509 certificates
+- `Example:` OSPOs work with IEEE on standards for governance of open source projects
 
 ### Big Project Facilitators
 

--- a/ospo-mindmap/Content/ospomindmap.md
+++ b/ospo-mindmap/Content/ospomindmap.md
@@ -30,6 +30,11 @@ efficient through sharing costs and innovation for industry-specific needs
 - `Definition` Work on foundational technology problems that cross industries
 - `Example:` Bloomberg worked with Microsoft to make contributions to TypeScript
 
+### Standards Collaborative
+
+- `Definition` Support relevant standards in open source projects and provide feedback to corresponding standards organizations
+- `Example:` OpenDaylight community collaborates with IETF standards community on NETCONF, RESTCONF, YANG, and YANG models
+
 ### Big Project Facilitators
 
 - `Definition` Form or facilitate the formation of large, complex 

--- a/ospo-mindmap/Content/ospomindmap.md
+++ b/ospo-mindmap/Content/ospomindmap.md
@@ -33,8 +33,7 @@ efficient through sharing costs and innovation for industry-specific needs
 ### Standards Collaborative
 
 - `Definition` Support relevant standards in open source projects and provide feedback to corresponding standards organizations
-- `Example:` Let's Encrypt community collaborates with IETF standards community on ACME, TLS, and other work related to X.509 certificates
-- `Example:` OSPOs work with IEEE on standards for governance of open source projects
+- `Example:`Encourage and guide members of their organization to participate in both the Let's Encrypt community and the IETF standards community on ACME, TLS, and other work related to X.509 certificates
 
 ### Big Project Facilitators
 


### PR DESCRIPTION
I believe OSPO behavior should include collaboration with standards organizations and communities as well as with industry and cross industry. This PR adds "Standards Collaborative" as a "Behavior" in the OSPO Mind Map.