### PR TITLE
Define OSPOlogy repo governance process

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,33 @@
+# OSPOlogy Repo Governance
+
+This document defines the governance process for the OSPOlogy repo. This doc outlines the various responsibilities of contributor roles in OSPOlogy, and clarifies how people can make their way up the OSPOlogy contributor ladder.
+
+| Role | Responsibilities | Requirements | Defined by |
+| -----| ---------------- | ------------ | -------|
+| OSPOlogy Contributor | Active contributor in the community | One successful merge of significant pull requests within the OSPOlogy repo | [OSPOlogy contirbutors](https://github.com/orgs/todogroup/teams/ospology-contributors) GH team|
+| OSPOlogy Maintainer | See "Expectations from Maintainers" bellow| 10+ successful merges of significant pull requests within the OSPOlogy repo AND fulfill the "Expectations from Maintainers" | [settings.yml file](https://github.com/todogroup/ospology/blob/main/.github/settings.yml#L18)|
+
+## Changes in Maintainership
+
+10+ successful merges of significant pull requests within the OSPOlogy repo, any current maintainer can reach to the author behind the pull requests and ask them if they are willing to become a mainatiner. They can also send a PR to [settings.yml file](https://github.com/todogroup/ospology/blob/main/.github/settings.yml#L18) and request the existing maintainers to vote them in.
+
+If a maintainer feels they can not fulfill the "Expectations from Maintainers", they are free to step down.
+
+## Voting process
+
+Existing maintainers vote a new maintainer. All voting is done via a simple majority of maintainers.
+In case of conflict resolution, the [TODO Steering Committee](https://github.com/todogroup/governance/blob/master/CHARTER.adoc) will have the final oversight.
+
+## Expectations from Maintainers
+
+Every one carries water and helps out!
+
+Every maintainer is listed in the [settings.yml file](https://github.com/todogroup/ospology/blob/main/.github/settings.yml#L18) 
+
+Making a community work requires input and effort from everyone.
+
+Maintainers should:
+* (1) Actively participate in PR reviews and respond in a timely fahsion AND 
+* (2) Be ready to moderate OSPOlogy meetings and/or regional TODO calls, if necessary.
+* (3) Review / approve / decline contributions from other contributors 
+


### PR DESCRIPTION
This doc defines the governance process for the OSPOlogy repo. This doc outlines the various responsibilities of contributor roles in OSPOlogy, and clarifies how people can make their way up the OSPOlogy contributor ladder.

Signed-off-by: Ana Jimenez Santamaria <ana@todogroup.org>