### PR TITLE
surface 'Sponsors open source' higher up

### DIFF
--- a/ospo-mindmap/Content/ospomindmap.md
+++ b/ospo-mindmap/Content/ospomindmap.md
@@ -129,9 +129,7 @@ development team of the Linux Project
 - License Compliance Policies
 
 
-### 📝 Establish and Improve Open Source Policies and Processes
-
-##### Policies
+### 📝 Establish and Improve Open Source Policies
 
 - Using open source and open source compliance policy
   - Forking an open source project
@@ -151,7 +149,7 @@ development team of the Linux Project
   - Risk assessment and acceptance  
   - Business alignment
 
-#### Processes
+### 💪 Establish and Improve Open Source Processes
 
 - Creating Open Source
   - Contributing to third-party OSS projects during work time
@@ -175,11 +173,6 @@ development team of the Linux Project
       - Review licenses of dependencies used by contributed code
     - Provide guidance to contributors on open source community ways of working
     - Publishing of project's release artifacts to public repositories such as Maven Central, npm, etc.
-  - Sponsoring Open Source
-    - Sponsoring third-party projects or individuals
-    - Sponsoring open source organizations
-    - Sponsoring own organization's open source projects or individual members
-    - Sponsoring events
   - Signing contribution related agreements
     - Contributor license agreement (individual / corporate)
     - Developer certificate of origin
@@ -219,6 +212,11 @@ development team of the Linux Project
   - Assist speakers for coding forums / conferences
 - Measuring Open Source
   - Develop, execute and improve measuring the impact of your organization's open source activities
+- Sponsoring Open Source
+  - Sponsoring third-party projects or individuals
+  - Sponsoring open source organizations
+  - Sponsoring own organization's open source projects or individual members
+  - Sponsoring events
 
 ### 📈 Prioritize and Drive Open Source Upstream Development
 


### PR DESCRIPTION
This PR surfaces "Sponsoring open source" higher up in the tree. It does this w/ 2 changes:

1. Separate "📝 Establish and Improve Open Source Policies and Processes" into:
  * 📝 Establish and Improve Open Source Policies
  * 💪 Establish and Improve Open Source Processes
2. Moving "Sponsoring open source" adjacent to "Creating Open Source" (instead of as a child)

#### Before
<img width="987" alt="image" src="https://user-images.githubusercontent.com/8397708/190679656-3dd17393-2892-417a-8e55-c29e7d6fc5cd.png">

#### After
<img width="820" alt="image" src="https://user-images.githubusercontent.com/8397708/190679575-9d9232b4-74fe-4a68-9f3b-71cb3198b8c4.png">
