### PR TITLE
Fix link to https://markmap.js.org/docs

### DIFF
--- a/ospo-mindmap/README.md
+++ b/ospo-mindmap/README.md
@@ -42,7 +42,7 @@ Follow these steps to create a new version of the Mind map:
 
 **Markmap Syntax**
 
-Markmap is a tool (under [MIT licence](https://github.com/gera2ld/markmap/blob/master/LICENSE)) designed by @gera2ld that parses markdown content and extract its intrinsic hierarchical structure and renders an interactive mindmap, aka markmap. Please see [markmap documentation](https://markmap.js.org/docs/) for further details.
+Markmap is a tool (under [MIT licence](https://github.com/gera2ld/markmap/blob/master/LICENSE)) designed by @gera2ld that parses markdown content and extract its intrinsic hierarchical structure and renders an interactive mindmap, aka markmap. Please see [markmap documentation](https://markmap.js.org/docs) for further details.
 
 ### Visualization and html generation
 


### PR DESCRIPTION
Very tiny fix 😁 

Took me a few back and forth clicks to work out that it's the trailing slash that makes this link not work!

`https://markmap.js.org/docs/` => `https://markmap.js.org/docs` works - it will redirect to the next page, but this is the same path that Markmap's website links to in the header.

