### PR TITLE
Deduplicate content from 'Eliminate friction' section

### DIFF
--- a/ospo-mindmap/Content/ospomindmap.md
+++ b/ospo-mindmap/Content/ospomindmap.md
@@ -88,6 +88,7 @@ development team of the Linux Project
 - Marketing
 - Communications
 - Growing and retaining open source talent
+- Maintain relationships with communities of strategic importance to your organization
 
 ### 🔍 Oversee Open Source Compliance
 
@@ -148,6 +149,7 @@ development team of the Linux Project
 - Policy on making open source business decisions
   - Risk assessment and acceptance  
   - Business alignment
+- Help navigate internal politics or policies
 
 ### 💪 Establish and Improve Open Source Processes
 
@@ -266,6 +268,7 @@ incubation and post launch
 
 #### Optimize Open Outbound Source Contributions
 
+
 ### 🤝 Collaborate with Open Source Organizations
 
 ##### 📖 Open Standards
@@ -306,9 +309,8 @@ incubation and post launch
 - Increase productivity, quality, code re-use, transparency and trust
 - Establish communication channels across the organization
 - Improve collaboration across the organization
-  - Help navigate internal politics or policies
 - Remove organizational silos and identify talent across the organization
-- Maintain relationships with communities of strategic importance to your organization
+
 
 ### 🫶 Grow and Retain Open Source Talent Inside the Organization
 

--- a/ospo-mindmap/Content/ospomindmap.md
+++ b/ospo-mindmap/Content/ospomindmap.md
@@ -266,7 +266,6 @@ incubation and post launch
 
 #### Optimize Open Outbound Source Contributions
 
-
 ### 🤝 Collaborate with Open Source Organizations
 
 ##### 📖 Open Standards
@@ -307,8 +306,9 @@ incubation and post launch
 - Increase productivity, quality, code re-use, transparency and trust
 - Establish communication channels across the organization
 - Improve collaboration across the organization
+  - Help navigate internal politics or policies
 - Remove organizational silos and identify talent across the organization
-
+- Maintain relationships with communities of strategic importance to your organization
 
 ### 🫶 Grow and Retain Open Source Talent Inside the Organization
 
@@ -344,13 +344,6 @@ incubation and post launch
 - Design OSS infrastructure
 - Metrics acquisition and dashboard
 - Third-party development tool management such as GitHub, GitLab, etc.
-
-
-### 🧭 Eliminate Friction from Using and Contributing to Open Source
-
-- Continuously improve processes and tools to reduce learning curve and manual effort required
-- Help navigate internal politics or policies
-- Maintain relationships with communities of strategic importance to your organization
 
 ### 📒 Support Corporate Development Activities
 


### PR DESCRIPTION
IMO, the content under "Eliminate Friction from Using and Contributing to Open Source" is duplicated in other sections, most strongly in the InnerSource one. This PR distributes that content into the other sections.

I also removed "Continuously improve processes and tools to reduce learning curve and manual effort required" since it felt redundant—we already have 2 other sections on improving processes and policies, and other bullets on making contributing better or easier. 🙂 

What do you think @tsteenbe @anajsana? 