### PR TITLE
Add link to presentation about CHAOSS tooling for OSPOs

### DIFF
--- a/ospology-live/2023-january-netherlands/presentations/chaoss-tooling-for-ospos-with-grimoirelab.md
+++ b/ospology-live/2023-january-netherlands/presentations/chaoss-tooling-for-ospos-with-grimoirelab.md
@@ -1,0 +1,1 @@
+👉 Download PDF slides [Here](https://speakerdeck.com/canasdiaz/ospology-chaoss-tooling-for-ospos-how-to-build-ospo-metrics-in-grimorelab)


### PR DESCRIPTION
Add link to slides of the presentation for OSPOlogy.live in Amsterdam with the title: "CHAOSS Tooling for OSPOs: how to build OSPO metrics in GrimoreLab"

Signed-off-by: Luis Cañas-Díaz <lcanas@bitergia.com>