### PR TITLE
chore(2025-02-27.md): add CFP dates

### DIFF
--- a/newsletter/2025-02-27.md
+++ b/newsletter/2025-02-27.md
@@ -52,7 +52,10 @@ Acknowledging contributions made to TODO and OSPOlogy initiatives from our commu
   
 ## 📎 Upcoming Conferences and Call for Papers
 
-- ADD CFP AND CONFERENCE DATES
+- June 23-24, 2025 [Open Source Summit North America](https://events.linuxfoundation.org/open-source-summit-north-america/) - CFP closed
+- Aug 5, 2025 [Open Source Summit India](https://events.linuxfoundation.org/open-source-summit-india/) - CFP due 6 April, 2025
+- Aug 25-27, 2025 [Open Source Summit Europe](https://events.linuxfoundation.org/open-source-summit-europe/) - CFP due 14 April, 2025
+- August 26-28, 2025 [GopherCon](https://www.gophercon.com/) - CFP due 3 March, 2025
   
 Format to use with Examples:
 ```


### PR DESCRIPTION
Adds the following CFP dates and conferences to the newsletter which will be published on Thursday, February 27 2025

- June 23-24, 2025 [Open Source Summit North America](https://events.linuxfoundation.org/open-source-summit-north-america/) - CFP closed
- Aug 5, 2025 [Open Source Summit India](https://events.linuxfoundation.org/open-source-summit-india/) - CFP due 6 April, 2025
- Aug 25-27, 2025 [Open Source Summit Europe](https://events.linuxfoundation.org/open-source-summit-europe/) - CFP due 14 April, 2025
- August 26-28, 2025 [GopherCon](https://www.gophercon.com/) - CFP due 3 March, 2025