### PR TITLE
fix(CODEOWNERS): secure repository with the right groups

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,5 +8,5 @@
 /.github/workflows/review-docs.yaml  @todogroup/ospology-book-infra
 
 # secure the repository
-/CODEOWNERS                          @anajsana
-/.github/settings.yml                @anajsana
+/.github/CODEOWNERS                  @todogroup/steering-committee @anajsana
+/.github/settings.yml                @todogroup/steering-committee @anajsana


### PR DESCRIPTION
The change reassigns ownership of the `.github/CODEOWNERS` and `.github/settings.yml` files to the `@todogroup/steering-committee` team.