### PR TITLE
fix(style): relax gender bias

### DIFF
--- a/.vale/TODO/GenderBias.yml
+++ b/.vale/TODO/GenderBias.yml
@@ -35,7 +35,6 @@ swap:
   repair(?:m[ae]n|wom[ae]n): technician(s)
   sales(?:m[ae]n|wom[ae]n): salesperson or sales people
   service(?:m[ae]n|wom[ae]n): soldier(s)
-  steward(?:ess)?: flight attendant
   tribes(?:m[ae]n|wom[ae]n): tribe member(s)
   waitress: waiter
   woman doctor: doctor


### PR DESCRIPTION
Steward is also used for example as data steward. This is not a flight attendant.