### PR TITLE
feat(vale): checks for EmDashes, Slash, and SpatialReferences

### DIFF
--- a/.vale/TODO/EmDashes.yml
+++ b/.vale/TODO/EmDashes.yml
@@ -1,0 +1,13 @@
+extends: existence
+ignorecase: true
+level: error
+scope: raw
+nonword: true
+message: "Don't put a space before and after a dash."
+tokens:
+  - ' --'
+  - '-- '
+  - ' —'
+  - '— '
+  - ' &mdash;'
+  - '&mdash; '

--- a/.vale/TODO/Slash.yml
+++ b/.vale/TODO/Slash.yml
@@ -1,0 +1,11 @@
+extends: existence
+message: "'%s' should be '%s'."
+level: error
+action:
+  name: edit
+  params:
+    - regex
+    - '(\w+)/(\w+)'
+    - '$1 and $2'
+tokens:
+  - '\w+/\w+'

--- a/.vale/TODO/SpatialReferences.yml
+++ b/.vale/TODO/SpatialReferences.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: "https://style-guide.ah.technology/#spatial-references"
+level: suggestion
+ignorecase: true
+swap:
+  "(?:see|the) above": preceding
+  "(?:see|the) below": following
+  "(?:see|the) left": preceding
+  "(?:see|the) right": following


### PR DESCRIPTION
**EmDashes**: The opposite of the Google and Microsoft style, but it works as described in the OSPO style guide.

**Slash**: Suggests to use 'and' instead of a slash.

**SpatialReference**: Works as intended, an author can always choose not to replace it.

Fixes: #622