### PR TITLE
Update book content with updated Vale rules

### DIFF
--- a/.vale/TODO/EmDashes.yml
+++ b/.vale/TODO/EmDashes.yml
@@ -1,7 +1,7 @@
 extends: existence
 ignorecase: true
 level: error
-scope: raw
+scope: sentence
 nonword: true
 message: "Don't put a space before and after a dash."
 tokens:

--- a/ospo-book/content/en/00-chapter.md
+++ b/ospo-book/content/en/00-chapter.md
@@ -6,7 +6,7 @@ weight: 20
 
 ## What's This Book About?
 
-Open source is a reality for all organizations that work with software — not just for software companies. Because of this, actively managing open source is becoming increasingly important for many organizations.
+Open source is a reality for all organizations that work with software—not just for software companies. Because of this, actively managing open source is becoming increasingly important for many organizations.
 
 One way to manage open source is by setting up an Open Source Program Office (OSPO). Many companies and organizations have adopted this approach, and there is now a lot of shared experience and knowledge about how to do it successfully. In the open source spirit, much of this knowledge is openly available in the community.
 

--- a/ospo-book/content/en/02-chapter.md
+++ b/ospo-book/content/en/02-chapter.md
@@ -79,7 +79,7 @@ The European Commission's Open Source Program Office (OSPO) has launched a new p
 
 In a world governed by software, Open Source Program Offices (OSPOs) serve as powerful cultural catalysts within organizations. Beyond simply managing technical integration of open source solutions, OSPOs fundamentally transform organizational culture by fostering open collaboration, transparency, and innovation.
 
-As organizations increasingly rely on open source for mission-critical problems — whether social, economic, or technological — the OSPO's cultural influence becomes essential in reshaping mindsets and workflows. This cultural shift enables organizations to move beyond viewing open source as merely a resource to extract value from, toward becoming active, contributing members of the broader open source ecosystem. By embedding open source values and practices throughout an organization, OSPOs cultivate internal champions, establish collaborative norms, and nurture a culture where knowledge sharing thrives.
+As organizations increasingly rely on open source for mission-critical problems—whether social, economic, or technological—the OSPO's cultural influence becomes essential in reshaping mindsets and workflows. This cultural shift enables organizations to move beyond viewing open source as merely a resource to extract value from, toward becoming active, contributing members of the broader open source ecosystem. By embedding open source values and practices throughout an organization, OSPOs cultivate internal champions, establish collaborative norms, and nurture a culture where knowledge sharing thrives.
 
 This cultural transformation not only supports risk management and innovation but ensures the sustainability of the open source communities they depend on. Without an OSPO's ongoing cultural influence, organizations risk losing open source expertise, increasing security and legal vulnerabilities, reducing community engagement, and damaging their reputation.
 
@@ -117,7 +117,7 @@ _[Source: OSPOs, key lever for open source sustainability][1](https://speakerdec
 
 ### Assess the Value of Open Source Use
 
-Organizations may underestimate how much they already depend on the usage of open source. Several studies analyze the usage of OSS in the industry. For example, the *Synopsys Open Source Security and Risk Analysis Report 2024* [^2] finds that the average software project consists of 77% OSS. Additionally, a *Harvard Business School study* [^3] estimates that the supply-side value of widely-used OSS is $4.15 billion, while the demand-side value is much larger at $8.8 trillion. Moreover, a study by OpenForum Europe [^4] estimates that OSS contributes between €65 to €95 billion to the European Union’s GDP and promises significant growth opportunities for the region’s digital economy.
+Organizations may underestimate how much they already depend on the usage of open source. Several studies analyze the usage of OSS in the industry. For example, the *Synopsys Open Source Security and Risk Analysis Report 2024* [^2] finds that the average software project consists of 77% OSS. Additionally, a *Harvard Business School study* [^3] estimates that the supply side value of widely used OSS is $4.15 billion, while the demand-side value is much larger at $8.8 trillion. Moreover, a study by OpenForum Europe [^4] estimates that OSS contributes between €65 to €95 billion to the European Union’s GDP and promises significant growth opportunities for the region’s digital economy.
 
 Assess this value for your own organization by taking steps such as:
 
@@ -144,7 +144,7 @@ To illustrate how your OSPO may deliver value to your organization, some example
 
 ### Managing a Vulnerability in the Software Supply Chain
 
-For example: a social engineering attack targeted the xz/liblzma [^5], an essential open source library. The attack was meticulously planned, gaining trust within the community before executing a malicious attack. This incident was discovered inadvertently by an unrelated project, underscoring the sophistication and stealthiness of such vulnerabilities. The challenge for OSPOs lies in identifying and mitigating these vulnerabilities, which are not always apparent until after they occur. Despite existing procedures and policies, OSPOs recognize the need for mechanisms to proactively measure and respond to such threats.
+For example: a social engineering attack targeted the `xz/liblzma` [^5], an essential open source library. The attack was meticulously planned, gaining trust within the community before executing a malicious attack. This incident was discovered inadvertently by an unrelated project, underscoring the sophistication and stealthiness of such vulnerabilities. The challenge for OSPOs lies in identifying and mitigating these vulnerabilities, which are not always apparent until after they occur. Despite existing procedures and policies, OSPOs recognize the need for mechanisms to proactively measure and respond to such threats.
 
 #### How the OSPO Helps
 
@@ -215,8 +215,7 @@ The OSPO struggles with gaining executive support and buy-in.
 
 ### Recommendation
 
-Executives require a particular type of communication. They need to have a clear picture of the role and value that each part of the organization brings. If the message is too detailed or vague, or if the subject is too specialist they can struggle to "get it". As the OSPO, you need to communicate the strategic value of open source and of the work the OSPO does to manage it. Showcasing visible benefits through case studies, success stories, or numerical reports can help to cut through with a clear and simple presentation that demonstrates OSPO initiatives are delivering with key organizational priorities.
-
+Executives require a particular type of communication. They need to have a clear picture of the role and value that each part of the organization brings. If the message is too detailed or vague, or if the subject is too specialist they can struggle to "get it." As the OSPO, you need to communicate the strategic value of open source and of the work the OSPO does to manage it. Showcasing visible benefits through case studies, success stories, or numerical reports can help to cut through with a clear and simple presentation that demonstrates OSPO initiatives are delivering with key organizational priorities.
 
 ## Resources and Footnotes
 
@@ -245,7 +244,7 @@ Executives require a particular type of communication. They need to have a clear
 
 [^4]: Study by OpenForum Europe: https://openforumeurope.org/publications/study-about-the-impact-of-open-source-software-and-hardware-on-technological-independence-competitiveness-and-innovation-in-the-eu-economy/
 
-[^5]: Social engineering attack targeted the xz/liblzma: https://research.swtch.com/xz-timeline
+[^5]: Social engineering attack targeted the `xz/liblzma`: https://research.swtch.com/xz-timeline
 
 [^6]: OpenSSF Scorecard: https://scorecard.dev/
 

--- a/ospo-book/content/en/03-chapter.md
+++ b/ospo-book/content/en/03-chapter.md
@@ -72,11 +72,11 @@ Depending on the complexity of your organization and the resources available to 
 
 * **Individual Contributors:** This petal represents the people who the OSPO will work within the organization, focusing on the intrinsic and extrinsic motivators of contributing to open source from an individual point of view. It requires a cultural change effort and may involve activities such as establishing mentoring programs.
 
-* **Management:** In this petal, the OSPO focuses on strategy and finding alignment between open source and the overall business/organization strategy. Managers face unique challenges, and using the strengths of open source helps them overcome these challenges effectively.
+* **Management:** In this petal, the OSPO focuses on strategy and finding alignment between open source and the overall business or organization strategy. Managers face unique challenges, and using the strengths of open source helps them overcome these challenges effectively.
 
 * **Legal:** This petal represents the legal aspects of open source. It deals with understanding and managing legal requirements and obligations related to open source initiatives within the organization. This ensures compliance and reduces legal risks.
 
-* **Business:** This petal focuses on how the OSPO ensures all the pieces of the organization structure fit together. It involves sharing best practices across different business/team units and fostering collaboration and knowledge transfer.
+* **Business:** This petal focuses on how the OSPO ensures all the pieces of the organization structure fit together. It involves sharing best practices across different business or team units and fostering collaboration and knowledge transfer.
 
 * **Open Source Ecosystem:** This petal represents the broader open source community and project ecosystem outside the organization. The OSPO engages with this ecosystem, which includes other organizations, projects, and individuals, to exchange ideas, collaborate, and contribute to the larger open source community.
 
@@ -144,7 +144,7 @@ Here are some suggestions of how you could use the ideas and advice above to set
 
 ### Using a Simple Checklist
 
-The TODO OSPO checklist [^8] offers a simplified set of common milestones to both early-stage and seasoned OSPOs in navigating each stage of the previously mentioned OSPO maturity model. Please note that an OSPO might remove, add, or edit some content of this checklist to adapt it to their organization's needs.
+The TODO OSPO checklist [^8] offers a simplified set of common milestones to both early stage and seasoned OSPOs in navigating each stage of the previously mentioned OSPO maturity model. Please note that an OSPO might remove, add, or edit some content of this checklist to adapt it to their organization's needs.
 
 ### Using Maturity Models
 
@@ -159,7 +159,7 @@ Here are some highlights from their work to inspire you:
 
 > NOTE: You can find a summary of their work in both Japanese and English in a Qiita article written by one of its members [^9]
 
-While planning the OSPO it's very helpful have 1:1 conversations with managers, high-level executives, and workers/contractors from different teams that use open source in their day-to-day operations, or whose strategy involves dealing with open source projects (in terms of licenses, security vulnerabilities). Use the insights from these conversations to define the organization's unique motivators and map them to areas within the organization where open source brings value.
+While planning the OSPO it's very helpful have 1:1 conversations with managers, high-level executives, and workers and contractors from different teams that use open source in their day-to-day operations, or whose strategy involves dealing with open source projects (in terms of licenses, security vulnerabilities). Use the insights from these conversations to define the organization's unique motivators and map them to areas within the organization where open source brings value.
 
 This will also help to build support for your work across the business even before the OSPO is officially created and launched.
 

--- a/ospo-book/content/en/04-chapter.md
+++ b/ospo-book/content/en/04-chapter.md
@@ -73,7 +73,7 @@ In the following table, Ibrahim H.'s open source activity engagement model (prev
 | Activities                             | Value for the OSPO | Value for the  Organization                                                                                                                                                      |
 | -------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Create contribution policy and process | Managing open source contributions becomes easier. | Having clear procedures means that the organization can offer open source contributions in a legally safe way, for open source projects, the organization, and its employees. |
-| Qualification of contributors          | Contributors require less oversight and make good ambassadors. | Skilled contributors make better contributions into publicly-visible projects. This means less risk to the organization.               |
+| Qualification of contributors          | Contributors require less oversight and make good ambassadors. | Skilled contributors make better contributions into publicly visible projects. This means less risk to the organization.               |
 
 #### STAGE: Leadership
 

--- a/ospo-book/content/en/05-chapter.md
+++ b/ospo-book/content/en/05-chapter.md
@@ -22,9 +22,9 @@ Open source software is an important part of the software supply chain. Because 
 
 This chapter includes useful resources to help OSPOs and open source developers apply secure software development and supply chain best practices - both in the software they use and the software they create.
 
-In some ways, security is just like any other requirement. However, many software developers and their managers haven't received enough training in security. Also, security is about defending against intelligent attackers, and it often depends on how the entire system works together — not just on one part.
+In some ways, security is just like any other requirement. However, many software developers and their managers haven't received enough training in security. Also, security is about defending against intelligent attackers, and it often depends on how the entire system works together—not just on one part.
 
-Fixing security problems later is often expensive. It's better to prevent them, reduce their chances or impact, and be prepared in case something still goes wrong. It's important to plan from the beginning and allocate resources (such as time and money) to handle security properly. Open source software can have a security advantage because it allows for mass peer review and follows the principle of "open design" — but these benefits don't happen automatically.
+Fixing security problems later is often expensive. It's better to prevent them, reduce their chances or impact, and be prepared in case something still goes wrong. It's important to plan from the beginning and allocate resources (such as time and money) to handle security properly. Open source software can have a security advantage because it allows for mass peer review and follows the principle of "open design"—but these benefits don't happen automatically.
 
 ## Training and Education
 
@@ -59,10 +59,10 @@ Both developers and managers must understand any laws or regulations they need t
 
 **Protect your environments, including development, build, test, and distribution:**
 
-1. Use multi-factor authentication (MFA) to make it harder for attackers to gain access.
+1. Use Multi-Factor Authentication (MFA) to make it harder for attackers to gain access.
 1. Secure your build environment. See OpenSSF SLSA for more guidance [^11].
 
-**Use automated tools in your continuous integration (CI) pipeline to catch security issues early:**
+**Use automated tools in your Continuous Integration (CI) pipeline to catch security issues early:**
 
 1. Use multiple types of tools, as each may find different problems, see the Guide to Security Tools [^12].
 
@@ -70,7 +70,7 @@ Both developers and managers must understand any laws or regulations they need t
 
 1. Enable tools that detect known vulnerabilities in reused components
 
-Prepare for vulnerability reports — they can happen to any project. Clearly explain how people can report vulnerabilities. Open source projects should review the OpenSSF Guide to implementing a coordinated vulnerability disclosure process [^13].
+Prepare for vulnerability reports—they can happen to any project. Clearly explain how people can report vulnerabilities. Open source projects should review the OpenSSF Guide to implementing a coordinated vulnerability disclosure process [^13].
 
 ## Applying This to Your Organization
 
@@ -82,7 +82,7 @@ Training and education should happen regularly, not just once. Developers and ma
 
 It also helps to be open about security progress. Encourage teams to track and share their progress on goals like earning Best Practices badges or improving their Scorecard results. This creates a positive environment where teams help each other and improve together, instead of feeling blamed when something goes wrong.
 
-Lastly, support continuous improvement. Security isn't something you finish — it's always changing. Set up regular times to review risks, update tools and practices, and share what your teams have learned. Give teams the freedom to make decisions about security early in the development process, not just at the end or after a problem happens.
+Lastly, support continuous improvement. Security isn't something you finish—it's always changing. Set up regular times to review risks, update tools and practices, and share what your teams have learned. Give teams the freedom to make decisions about security early in the development process, not just at the end or after a problem happens.
 
 By creating a culture of shared responsibility, adding security into everyday work, investing in learning, encouraging openness, and improving over time, your organization can make real progress in securing the OSS it builds and uses.
 

--- a/ospo-book/content/en/06-chapter.md
+++ b/ospo-book/content/en/06-chapter.md
@@ -14,7 +14,7 @@ weight: 70
 
 > NOTE: This chapter has been developed through the collective expertise of CHAOSS open source project and participants from the CHAOSS OSPO Metrics Working Group, with support from the TODO Group.
 
-Metrics are an important part of any modern organization. When used effectively, they offer a valuable way to track the impact of your team and its projects. For an OSPO, metrics not only support planning and measuring the impact of its work — they also provide deeper insight into the open source projects the organization depends on.
+Metrics are an important part of any modern organization. When used effectively, they offer a valuable way to track the impact of your team and its projects. For an OSPO, metrics not only support planning and measuring the impact of its work—they also provide deeper insight into the open source projects the organization depends on.
 
 In the past, it might have been acceptable to know little about key open source projects. But that's no longer a sustainable approach as the regulatory and security landscape around open source continues to evolve. As we deepen our understanding of the open source projects that matter to us, community metrics become essential tools. In this chapter, we'll explore how to place those metrics in context and how, together, they can offer better insights to guide strategic decisions across an organization.
 
@@ -93,7 +93,7 @@ Evaluate how employee engagement in open source communities reflects organizatio
 
 **Commentary**
 
-There are ways that an organization can support community engagement by employees (for example contribution guidelines, intellectual property management, and license support). Support will often include why the community is important to your organization - including a time and prioritization component in how much time an employee spends in external/upstream work. companies can observe employees as good citizens for reasons of personal and organizational gain, and help employees understand their importance in bridging between the organization and the community.
+There are ways that an organization can support community engagement by employees (for example contribution guidelines, intellectual property management, and license support). Support will often include why the community is important to your organization - including a time and prioritization component in how much time an employee spends in external and upstream work. companies can observe employees as good citizens for reasons of personal and organizational gain, and help employees understand their importance in bridging between the organization and the community.
 
 **Questions**
 

--- a/ospo-book/content/en/toc.md
+++ b/ospo-book/content/en/toc.md
@@ -6,7 +6,7 @@ weight: 10
 
 ## Chapter 1: Introduction to Open Source Program Offices
 
-This chapter introduces the concept of Open Source Program Offices (OSPOs), explaining what they are, where they come from, and why they matter. It includes guidance on assessing whether an organization is ready for an OSPO, along with common scenarios and early-stage recommendations.
+This chapter introduces the concept of Open Source Program Offices (OSPOs), explaining what they are, where they come from, and why they matter. It includes guidance on assessing whether an organization is ready for an OSPO, along with common scenarios and early stage recommendations.
 
 ## Chapter 2: The Value of Open Source Program Offices
 


### PR DESCRIPTION
This pull request primarily focuses on improving the readability and consistency of the OSPO book content by addressing grammar, formatting, and terminology issues. Additionally, it includes a minor configuration change in the `.vale` linting rule. Below is a summary of the most important changes grouped by theme.

### Grammar and Style Improvements:

* Updated phrasing for clarity and grammatical correctness, such as replacing "early-stage" with "early stage" and "publicly-visible" with "publicly visible" across multiple sections (`ospo-book/content/en/02-chapter.md`, `ospo-book/content/en/03-chapter.md`, `ospo-book/content/en/04-chapter.md`, `ospo-book/content/en/toc.md`). [[1]](diffhunk://#diff-6269f10f3c67897502356b28627abd1b2b7a118251d3b4dacf739d34943adb11L120-R120) [[2]](diffhunk://#diff-146a97b0ae46358b2f759f307e59c2f5f93d189649ff3cc25a100308a021fd21L147-R147) [[3]](diffhunk://#diff-0f4c64c1833fe8d5d4ca048ac948aa843479b435d79a76e74287fb7611bafca4L76-R76) [[4]](diffhunk://#diff-60f11ca9f29067dd6e1e9337243425aa928d33a26b341c443b69b38f6efde2d5L9-R9)
* Improved sentence structure and punctuation, such as fixing "get it" to "get it." for proper punctuation in `ospo-book/content/en/02-chapter.md`.

### Code and Formatting Adjustments:

* Enclosed code identifiers like `xz/liblzma` in backticks for consistency with markdown formatting in `ospo-book/content/en/02-chapter.md`. [[1]](diffhunk://#diff-6269f10f3c67897502356b28627abd1b2b7a118251d3b4dacf739d34943adb11L147-R147) [[2]](diffhunk://#diff-6269f10f3c67897502356b28627abd1b2b7a118251d3b4dacf739d34943adb11L248-R247)
* Capitalized terms like "Multi-Factor Authentication" and "Continuous Integration" for consistency in `ospo-book/content/en/05-chapter.md`.

### Linting Configuration Change:

* Updated the `.vale` linting configuration to change the `scope` from `raw` to `sentence`, to improve the accuracy and exclude MarkDown tables of linting checks in `.vale/TODO/EmDashes.yml`.

### Terminology Refinements:

* Replaced "workers/contractors" with "workers and contractors" for better readability in `ospo-book/content/en/03-chapter.md`.
* Clarified "external/upstream work" to "external and upstream work" for improved understanding in `ospo-book/content/en/06-chapter.md`.