### PR TITLE
Add minimal Hugo setup using the hugo-book theme

### DIFF
--- a/whitepapers/business-value/.gitignore
+++ b/whitepapers/business-value/.gitignore
@@ -1,0 +1,3 @@
+public
+resources
+.hugo_build.lock

--- a/whitepapers/business-value/README.md
+++ b/whitepapers/business-value/README.md
@@ -1,9 +1,9 @@
 ## Collaborative Whitepaper - Open Source in Business
 
 > Working Group Folder
-> 
+>
 > Slack channel #wg-oss-in-business
-> 
+>
 > Follow-up happening during Thursday TODO Europe Touchpoint CallS
 
 
@@ -23,7 +23,7 @@ Apporved proposal and rationale can be found [here](https://github.com/todogroup
 2.	Help non-software-native companies (e.g., hardware or manufacturing) understand how open source can play a role in their business models.
 3.	Educate business managers on the long-term investments required for successful open source strategies (e.g., building and nurturing open source communities).
 
-## Initial Outline 
+## Initial Outline
 
  [Glossary and Background - Existing frameworks and models](glossary.md) | [Engineering Driven vs. Business Driven Open Source](engineering-vs-business-driven.md) | [Misconceptions and Challenges](misconceptions_challenges.md) | [Communicating Engineering Benefits to Business Value](communication_of_benefits_to_business_value.md) | [Case Studies and Success Stories](case_studies_and_stories.md) | [Future work and conclusion](living_guide_for_business.md)
 -- | -- | -- | -- | -- | --
@@ -52,3 +52,7 @@ If you would like to catch up on motivation, interested participants involved, p
 
 - Define workstreams/cluster of tasks and give them an order/priority. Make sure there are “owners” for each workstream
 - Discuss if further follow-ups should be done in these meetings or need to allocate specific catch up calls/official working group under TODO
+
+## Displaying the Guide as Website
+
+The content of the guide is maintained in the `content` subdirectory as Markdown files. You can run [Hugo](https://gohugo.io) to render it as website. Run the command `hugo server` to start a web server locally and follow the instructions to view the site in your web browser.

--- a/whitepapers/business-value/content/en/_index.md
+++ b/whitepapers/business-value/content/en/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Business Value of Open Source"
+---
+
+This guide explores the business value of open source from multiple perspectives, providing frameworks and real-world examples to help organizations make informed decisions about their open source strategies. It covers topics ranging from basic definitions to advanced concepts in open source program management.

--- a/whitepapers/business-value/content/en/case_studies_and_stories.md
+++ b/whitepapers/business-value/content/en/case_studies_and_stories.md
@@ -1,3 +1,8 @@
+---
+title: Case Studies and Stories
+weight: 50
+---
+
 # Success Stories
 
 ## Microsoft and Kubernetes

--- a/whitepapers/business-value/content/en/communication_of_benefits_to_business_value.md
+++ b/whitepapers/business-value/content/en/communication_of_benefits_to_business_value.md
@@ -1,3 +1,8 @@
+---
+title: Communicating Engineering Benefits to Business Value
+weight: 30
+---
+
 - How to communicate open source benefits to business managers#
 - Simplifying complex concepts for managerial understanding
 - resources for managers to engage with open source effectively

--- a/whitepapers/business-value/content/en/engineering-vs-business-driven.md
+++ b/whitepapers/business-value/content/en/engineering-vs-business-driven.md
@@ -1,1 +1,6 @@
+---
+title: Engineering vs Business driven
+weight: 20
+---
+
 Definitions, Implementation strategies for business-driven, Connecting the two perspectives for a holistic approach

--- a/whitepapers/business-value/content/en/glossary.md
+++ b/whitepapers/business-value/content/en/glossary.md
@@ -1,3 +1,8 @@
+---
+title: Glossary and Intro
+weight: 10
+---
+
 # Preamble
 There is the engineering driven and the business driven side. The engineering driven side is typically already well represented in the Open Source community but for the business driven side we miss useful material.
 Therefore we collaborate on the “Open Source in business guide” and we want to convince business people, that they should consider Open Source as an additional strategic tool in their strategy toolbox. Additionally we want to enable the Open Source evangelists in the organizations to convince their business managers about considering Open Source as an alternative to classic approaches by providing them some good practices an material that can be re-used.
@@ -12,12 +17,12 @@ This file will serve as a reference guide to assist non-technical managers to un
 - OS - Open Source.
 - OSPO(s) - Open Source Program Office(s).
 - .Md - Mark Down File.
-- PR - Pull Requests. 
+- PR - Pull Requests.
 - SC - Steering Committee.
-- WG - Working Group. 
-- CFP - Call for Proposal. 
+- WG - Working Group.
+- CFP - Call for Proposal.
 
-# Concepts 
-- Pull Requests - This is a way of asking someone most likely a reviewer to look at your proposed changes and approve (merge) or decline. 
+# Concepts
+- Pull Requests - This is a way of asking someone most likely a reviewer to look at your proposed changes and approve (merge) or decline.
 - Steering Committee - These are group of people that serve as the regulating body for an Open Source Community or Project activities. They are also referred to as a Board in many Communities but in TODO they are refered to as the steering Committe.
-- Call for Proposal - This is a method where conference, meet ups and various programs issue a request (call) publicly for people to send in proposals to either speak or present a topic in their event. 
+- Call for Proposal - This is a method where conference, meet ups and various programs issue a request (call) publicly for people to send in proposals to either speak or present a topic in their event.

--- a/whitepapers/business-value/content/en/living_guide_for_business.md
+++ b/whitepapers/business-value/content/en/living_guide_for_business.md
@@ -1,2 +1,7 @@
+---
+title: Future work and conclusion
+weight: 90
+---
+
 - Creating a living document that evolves with community input
 - Recap of the guide’s key points

--- a/whitepapers/business-value/content/en/misconceptions_challenges.md
+++ b/whitepapers/business-value/content/en/misconceptions_challenges.md
@@ -1,3 +1,8 @@
+---
+title: Misconceptions
+weight: 40
+---
+
 - Misconceptions managers have about open source
 - Addressing security concerns and support availability
 - Cyber Resilience Act (CRA) when publishing software

--- a/whitepapers/business-value/go.mod
+++ b/whitepapers/business-value/go.mod
@@ -1,0 +1,7 @@
+module todogroup.org/resources/oss-business
+
+go 1.24.4
+
+require (
+	github.com/alex-shpak/hugo-book v0.0.0-20250815075559-80da168330a7 // indirect
+)

--- a/whitepapers/business-value/go.sum
+++ b/whitepapers/business-value/go.sum
@@ -1,0 +1,2 @@
+github.com/alex-shpak/hugo-book v0.0.0-20250815075559-80da168330a7 h1:zxGxqYjCcRUPz7r87qtOE/famdnIhqQOD75R9Vt2mpQ=
+github.com/alex-shpak/hugo-book v0.0.0-20250815075559-80da168330a7/go.mod h1:L4NMyzbn15fpLIpmmtDg9ZFFyTZzw87/lk7M2bMQ7ds=

--- a/whitepapers/business-value/hugo.toml
+++ b/whitepapers/business-value/hugo.toml
@@ -1,0 +1,19 @@
+baseURL = "https://example.com/"
+title = "Open Source in Business Guide"
+
+[module]
+  [[module.imports]]
+    path = "github.com/alex-shpak/hugo-book"
+
+[params]
+  BookSection = "*"
+
+defaultContentLanguage = "en"
+defaultContentLanguageInSubdir = false
+disableLanguages = ["en"]
+
+[languages]
+  [languages.en]
+    contentDir = "content/en"
+    weight = 1
+    languageName = "English"


### PR DESCRIPTION
This puts the actual content of the guide into the `content/en` directory and separates it from the other metadata like contribution guidelines and project setup. The minimal Hugo setup allows to show the content as Hugo-generated static website. Run `hugo server` to start it.