### PR TITLE
Revise OSPOlogy resource sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,57 +5,12 @@
 
 # 📖 OSPOlogy - The Study of Open Source Management  
 
-✨ **`OSPOlogy` is a platform for the study and open community dialogue about the state of open source management within organizations across various sectors.**  
+✨ **`OSPOlogy` is a platform for the study and open community about the state of open source management within organizations.**  OSPOlogy is an initiative by the [TODO Group](https://todogroup.org/). Our collective resources, including frameworks and resources on open source management best practices, are freely available for any organization to use, providing proper attribution to the repository and brand.
 
-- 💚 [What is OSPOlogy](#what-is-ospology)  
-- 🦺 [Activities and Frameworks](#activities-and-frameworks)  
-- 🕵️‍♀️ [Resources](#resources)  
-
----
-
-# What is OSPOlogy?  
-
-OSPOlogy is an initiative by the [TODO Group](https://todogroup.org/). Our collective resources, including frameworks and templates, are freely available for any organization to use, providing proper attribution to the repository and brand.
-
-## Forum
-
-The official forum (OSPOlogy GH Discussions) facilitates discussions on open source management, exploring its role across specializations (e.g., security, AI infrastructure, business strategy), addressing shared challenges (e.g., measuring the value of open source management and OSPOs), and fostering community-driven proposals.  
-
-## Activities and Frameworks  
-
-> [!note]  
-> By using OSPOlogy frameworks and attributing the brand, your organization is helping unify efforts and enhancing the visibility of the strategic value of open source management talent across diverse industries and business areas to key stakeholders, reducing resource fragmentation and duplication.
-
-### Virtual  
-
-#### 🔭 OSPOlogy Webinars (Archived)  
-
-These webinars cover OSPO-related topics with special guests and community discussions. All sessions are recorded, edited, and available on the [OSPOlogy YouTube Channel](https://www.youtube.com/channel/UCi-ELHAwzoYZvAs4FH-ShaA). Explore the event page and past sessions here: [OSPOlogy Webinars](https://github.com/todogroup/ospology/tree/main/meetings#event-page-and-past-sessions).
-
-> [!warning]
-> Since 2024, OSPOlogy Webinars are no longer active and these are being replaced with OSPOlogy TODO Touchpoints.
-
-#### 🗺 OSPOlogy TODO Touchpoints  
-
-Regional meetings (AMER, EMEA, APAC) provide open agendas and office hours for collaboration. Meeting schedules are available on the [community calendar](https://todogroup.org/community/meetings/).  
-
-### In-person
-
-#### ⭐️ OSPOlogy Birds of a Feather (BoF)
-
-Formerly called OSPO BoFs, this framework consists of semi-informal discussion sessions held at conferences, where participants with shared interests come together to discuss open source management and OSPO challenges and its strategic value in security, innovation, and collaboration within different industries, specializations, or technologies (e.g. Cloud Native, Energy, Automotive, Security, etc.). Current adopters include the Cloud Native Computing Foundation (CNCF).
-
-> [!important]
-> Framework used for [OSPOlogy BoF](https://github.com/todogroup/ospology/tree/main/BoF).
-
-#### ⭐️ OSPOlogy *Live* and OSPOlogy Local Meetups  
-
-These frameworks support mini-summits or local meetups organized by [OSPO Regional Ambassadors](https://todogroup.org/community/ambassadors/). The goal is to create forums where professionals can share knowledge and experience on the application of open source management to specific industries, technologies, and regions.  
-
-> [!important]
-> Framework used for [OSPOlogy Local Meetups](https://github.com/todogroup/ospology/tree/main/local-meetups).
->
-> Framework used for [OSPOlogy Live](https://github.com/todogroup/ospology/tree/main/ospology-live).
+- 🕵️‍♀️ [Resources](#resources)
+- 🦺 [Programs Framework](#programs-framework)  
+- 👋 [Forum](#forum)
+- 📝 [License](#license)
 
 ## Resources
 
@@ -63,10 +18,29 @@ Resources hosted under the OSPOlogy brand and supported by the TODO Community.
 
 ### 📖 OSPO Book
 
+| Version| Status | Working Group Formed? |
+| --- | --- | --- |
+|   1.0   |   Active development | Yes |
+
 The [OSPO Book](https://ospobook.todogroup.org/) includes resources developed collaboratively across organizations for effective open source management through OSPOs. It is intended for those organizations looking to develop strategies to use, contribute to, or create open source projects.
 [Find contribution guidelines here](https://github.com/todogroup/ospology/tree/main/ospo-book).  
 
+### 🧩 OSS in Business Guide
+
+| Version| Status | Working Group Formed? |
+| --- | --- | --- |
+|   Draft   |   Active development | Yes |
+
+The OSS in Business Guide focuses on articulating the business value of open source, helping organizations understand how open source contributes to strategic outcomes such as innovation, risk management, cost efficiency, and long-term sustainability.
+The guide is being developed collaboratively and is intended for decision-makers, OSPO practitioners, and stakeholders looking to better connect open source activities with business objectives.
+
+Contributions and ongoing development are tracked in the [dedicated repository](https://github.com/todogroup/ospology/tree/business_guide_dev/whitepapers/business-value/content)
+
 ### 📭 Newsletter  
+
+| Version| Status | Working Group Formed? |
+| --- | --- | --- |
+|   -   |   Active development | No |
 
 The OSPO newsletter is published monthly on the last Tuesday. [Subscribe here](https://todogroup.org/community/osponews/).  
 
@@ -74,10 +48,30 @@ Contribute to the newsletter by submitting a [pull request](https://github.com/t
 
 ### 🧭 OSPO MindMap
 
+| Version| Status | Working Group Formed? |
+| --- | --- | --- |
+|   2.0   |   Maintenance |  No |
+
 The [OSPO Mind Map](https://ospomindmap.todogroup.org/) provides a visual representation of an OSPO’s responsibilities, roles, behaviors, and team size within the ecosystem.  
 
 Contributors can propose updates for future versions in the [dedicated repository](https://github.com/todogroup/ospology/tree/main/ospo-mindmap).  
 
-## 📝 License  
+## Programs Framework  
+
+By using OSPOlogy frameworks and attributing the brand, your organization is helping unify efforts and enhancing the visibility of the strategic value of open source management talent across diverse industries and business areas to key stakeholders, reducing resource fragmentation and duplication.
+
+| Format | Program / Framework | Description | Notes / Links |
+| --- | --- | --- | --- |
+| Virtual | ⏸️ OSPOlogy Webinars (Archived) | Webinars covering OSPO-related topics with special guests and community discussions. All sessions are recorded, edited, and available on the OSPOlogy YouTube channel. | **Status:** Archived (since 2024). Replaced by OSPOlogy TODO Touchpoints.<br><br>[YouTube Channel](https://www.youtube.com/channel/UCi-ELHAwzoYZvAs4FH-ShaA)<br>[Event page & past sessions](https://github.com/todogroup/ospology/tree/main/meetings#event-page-and-past-sessions) |
+| Virtual | ⭐️ OSPOlogy TODO Touchpoints | Regional meetings (AMER, EMEA, APAC) providing open agendas and office hours for collaboration. | [Community calendar](https://todogroup.org/community/meetings/) |
+| In-person | ⭐️ OSPOlogy Birds of a Feather (BoF) | Semi-informal discussion sessions held at conferences, bringing together participants with shared interests to discuss open source management, OSPO challenges, and strategic value across industries and technologies. | **Framework:** https://github.com/todogroup/ospology/tree/main/BoF |
+| In-person | ⭐️ OSPOlogy *Live* and OSPOlogy Local Meetups | Mini-summits and local meetups organized by OSPO Regional Ambassadors to share knowledge and experience on applying open source management across industries, technologies, and regions. | **Frameworks:**<br>[OSPOlogy Local Meetups](https://github.com/todogroup/ospology/tree/main/local-meetups)<br>[OSPOlogy Live](https://github.com/todogroup/ospology/tree/main/ospology-live) |
+
+
+## Forum
+
+The official forum (OSPOlogy GH Discussions) facilitates discussions on open source management, exploring its role across specializations (e.g., security, AI infrastructure, business strategy), addressing shared challenges (e.g., measuring the value of open source management and OSPOs), and fostering community-driven proposals.  
+
+## License  
 
 This [repository](https://github.com/todogroup/ospology) is provided by the [TODO Group](https://todogroup.org) under the [Creative Commons Attribution 4.0 International License](./LICENSE).


### PR DESCRIPTION
Updated the README to re-order OSPOlogy's frameworks and resources and include loss in business guide info.

[preview](https://github.com/todogroup/ospology/blob/d9053c659e881c6bdf5af65410eb6da35b0dfaa0/README.md)
[related issue](https://github.com/todogroup/governance/issues/395)