### PR TITLE
Add general contributing file to ospology

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,9 +19,9 @@ This repository hosts multiple projects and event frameworks under the TODO Grou
 
 | Event | Guide | Description |
 |-------|-------|-------------|
-| 🌍 OSPOlogy Workshops | [ospology-live/README.md](ospology-live/framework.md) | Workshops and in-person gatherings |
+| 🌍 OSPOlogy Workshops | [ospology-live/framework.md](ospology-live/framework.md) | Workshops and in-person gatherings |
 | 🤝 OSPOlogy Virtual Meetings | [meetings/README.md](meetings/README.md) | Community meeting notes and recordings |
-| 🌍 OSPOlogy Local Meetups | [local-meetups/README.md](local-meetups/framework.md) | Regional OSPO meetups |
+| 🌍 OSPOlogy Local Meetups | [local-meetups/framework.md](local-meetups/framework.md) | Regional OSPO meetups |
 | 💬 OSPOlogy BoF | [BoF/README.md](BoF/README.md) | Birds of a Feather sessions |
 
 


### PR DESCRIPTION
The OSPOlogy repo contains multiple projects (OSPO Book, whitepapers, newsletter, etc), each with its own contribution guidelines. Currently, new contributors may not know where to start. This root CONTRIBUTING.md:

- Provides a clear overview of all projects and events
- Links directly to each sub-project's contributing guide or README

**Changes**: Adds `CONTRIBUTING.md` at root level with Projects table (OSPO Book, whitepapers, newsletter, mind map, model) and vents framework table (OSPOlogyLive, meetings, local meetups, BoF)