### PR TITLE
Create general CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing to OSPOlogy Repo
+
+Thank you for your interest in contributing to OSPOlogy! 🎉
+
+This repository hosts multiple projects and event frameworks under the TODO Group umbrella. Each has its own contribution guidelines and README
+
+## Projects
+
+| Project | Contributing Guide | Description |
+|---------|-------------------|-------------|
+| 📖 OSPO Book | [ospo-book/CONTRIBUTING.md](ospo-book/CONTRIBUTING.md) | The OSPO Book — a practical guide for OSPOs |
+| 📄 Business Value Whitepaper | [whitepapers/business-value/CONTRIBUTING.md](whitepapers/business-value/CONTRIBUTING.md) | Whitepaper on the business value of OSPOs |
+| 📄 OSPO Lifecycle Whitepaper | [whitepapers/ospo-lifecycle/README.md](whitepapers/ospo-lifecycle/README.md) | Whitepaper on the OSPO lifecycle |
+| 📰 Newsletter | [newsletter/README.md](newsletter/README.md) | Monthly OSPO community newsletter |
+| 🗺️ OSPO Mind Map | [ospo-mindmap/README.md](ospo-mindmap/README.md) | Visual representation of OSPO responsibilities |
+| 📊 OSPO Model | [ospo-model/README.md](ospo-model/README.md) | OSPO Maturity Model |
+
+## Events Framework
+
+| Event | Guide | Description |
+|-------|-------|-------------|
+| 🌍 OSPOlogy Workshops | [ospology-live/framework.md](ospology-live/framework.md) | Workshops and in-person gatherings |
+| 🤝 OSPOlogy Virtual Meetings | [meetings/README.md](meetings/README.md) | Community meeting notes and recordings |
+| 🌍 OSPOlogy Local Meetups | [local-meetups/framework.md](local-meetups/framework.md) | Regional OSPO meetups |
+| 💬 OSPOlogy BoF | [BoF/README.md](BoF/README.md) | Birds of a Feather sessions |
+
+
+## General Guidelines
+
+- **Issues**: Use the [issue templates](.github/ISSUE_TEMPLATE/) to report bugs, suggest content, propose translations, and more
+- **Pull Requests**: Create a branch and submit a PR
+
+
+## Code of Conduct
+
+This project follows the [TODO Group Code of Conduct](https://todogroup.org/about/code-of-conduct/).
+
+## Security
+
+To report security concerns, please open an [issue](https://github.com/todogroup/ospology/issues)


### PR DESCRIPTION
The OSPOlogy repo contains multiple projects (OSPO Book, whitepapers, newsletter, etc), each with its own contribution guidelines. Currently, new contributors may not know where to start. This root CONTRIBUTING.md:

- Provides a clear overview of all projects and events
- Links directly to each sub-project's contributing guide or README