### PR TITLE
adds GH action to build and deploy business guide to GH pages

### DIFF
--- a/.github/workflows/deploy-business-value.yaml
+++ b/.github/workflows/deploy-business-value.yaml
@@ -1,0 +1,56 @@
+name: Deploy Business Value Whitepaper Website
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'whitepapers/business-value/**'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: 'latest'
+          extended: true
+
+      - name: Build Hugo site
+        working-directory: whitepapers/business-value
+        run: hugo --minify
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./whitepapers/business-value/public
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/whitepapers/business-value/hugo.toml
+++ b/whitepapers/business-value/hugo.toml
@@ -1,4 +1,4 @@
-baseURL = "https://example.com/"
+baseURL = "https://todogroup.github.io/ospology/whitepapers/business-value/"
 title = "Open Source in Business Guide"
 
 [module]


### PR DESCRIPTION
With this PR I would like to add an GH action that builds a website out of the business guide in `/whitepapers/business_value` and deploys it to GH Pages. 

I know that there is also a [website for the OSPO](https://ospobook.todogroup.org) book. However, I do not know how the OSPO book is deployed and am unsure whether the action proposed here might interfere with the current OSPO book deployment. One reason is that the new action deploys to GH pages and overwrites the previous content of the GH pages storage in the process. I am tagging the OSPO Book infrastructure team (@cjyabraham @anajsana @koozz @CsatariGergely) to get their opinion. 

One requirement for this action to work is that the repository configuration in `Settings -> Pages -> Build and Deployment -> Source` is set to `GitHub Actions`. I can provide an alternative action if this setting has to be set to `Deploy from a branch`. In any case this would need to be set by one of the maintainers of this repository since I do not have access to the repository settings. 